### PR TITLE
Handle analysis of bwa output with hard clipping

### DIFF
--- a/cage_src/dataloader.cpp
+++ b/cage_src/dataloader.cpp
@@ -113,60 +113,69 @@ namespace cage {
             case ('='):
             case ('X'):
               for (int l = 0; l < op.Length; l++) {
-                if (al.MapQuality != 0 && al.Qualities.at(k) > '%' && j + pos_rel >= 0 && j + pos_rel < (int)(block_end - block_start)) {
-                  // Only count up mismatches; do not consider variants in soft-clipped region
-                  piles_seg.depth[j + pos_rel]++;
-                  if (al.QueryBases.at(k) == ref.at(j + pos_rel + block_start)) {
-                    piles_seg.matches[j + pos_rel]++;
-                  } else {
-                    if (params.call_variants) {
-                      vc->increment_mismatch(j + pos_rel, al.QueryBases.substr(k, 1), al.IsReverseStrand);
+		if (al.Qualities.size() > (unsigned)k) {
+                  if (al.MapQuality != 0 && al.Qualities.at(k) > '%' && j + pos_rel >= 0 && j + pos_rel < (int)(block_end - block_start)) {
+                    // Only count up mismatches; do not consider variants in soft-clipped region
+                    piles_seg.depth[j + pos_rel]++;
+                    if (al.QueryBases.at(k) == ref.at(j + pos_rel + block_start)) {
+                      piles_seg.matches[j + pos_rel]++;
+                    } else {
+                      if (params.call_variants) {
+                        vc->increment_mismatch(j + pos_rel, al.QueryBases.substr(k, 1), al.IsReverseStrand);
+                      }
                     }
                   }
-                }
+		}
                 j++; k++;
               }
               break;
 
+            case ('H'): // Hard-clipping
             case ('S'): // Soft-clipping
               for (int l = 0; l < op.Length; l++) {
-                if (al.MapQuality != 0 && al.Qualities.at(k) > '%' && j + pos_rel >= 0 && j + pos_rel < (int)(block_end - block_start)) {
-                  // Only increment the depth and number of matches; do not consider variants in soft-clipped region
-                  piles_seg.depth[j + pos_rel]++;
+		if (al.Qualities.size() > (unsigned)k) {
+                  if (al.MapQuality != 0 && al.Qualities.at(k) > '%' && j + pos_rel >= 0 && j + pos_rel < (int)(block_end - block_start)) {
+                    // Only increment the depth and number of matches; do not consider variants in soft-clipped region
+                    piles_seg.depth[j + pos_rel]++;
 
-                  if (al.QueryBases.at(k) == ref.at(j + pos_rel + block_start)) {
-                    piles_seg.matches[j + pos_rel]++;
-                  } else {
-                    //  cout << "Mismatch at " << j + pos_rel + block_start << seq[j] << memblock[j + pos_rel] << endl;
+                    if (al.QueryBases.at(k) == ref.at(j + pos_rel + block_start)) {
+                      piles_seg.matches[j + pos_rel]++;
+                    } else {
+                      //  cout << "Mismatch at " << j + pos_rel + block_start << seq[j] << memblock[j + pos_rel] << endl;
+                    }
                   }
-                }
+		}
                 j++; k++;
               }
               break;
 
             case ('I'):
-              if (al.MapQuality != 0 && j + pos_rel - 1 >= 0 && j + pos_rel - 1 < (int)(block_end - block_start)) {
-                piles_seg.indels[j + pos_rel - 1]++;
-                string alt_bases;
-                if (k == 0) {
-                  alt_bases = ref.at(j + pos_rel + block_start - 1) + al.QueryBases.substr(k, op.Length);
-                } else {
-                  alt_bases = al.QueryBases.substr(k - 1, op.Length + 1);
+	      if (al.Qualities.size() > (unsigned)k) {
+                if (al.MapQuality != 0 && j + pos_rel - 1 >= 0 && j + pos_rel - 1 < (int)(block_end - block_start)) {
+                  piles_seg.indels[j + pos_rel - 1]++;
+                  string alt_bases;
+                  if (k == 0) {
+                    alt_bases = ref.at(j + pos_rel + block_start - 1) + al.QueryBases.substr(k, op.Length);
+                  } else {
+                    alt_bases = al.QueryBases.substr(k - 1, op.Length + 1);
+                  }
+                  if (params.call_variants) {
+                    vc->increment_mismatch(j + pos_rel - 1, alt_bases, al.IsReverseStrand);
+                  }
                 }
-                if (params.call_variants) {
-                  vc->increment_mismatch(j + pos_rel - 1, alt_bases, al.IsReverseStrand);
-                }
-              }
+	      }
               k += op.Length;
               break;
 
             case ('D'):
-              if (al.MapQuality != 0 && j + pos_rel - 1 >= 0 && j + pos_rel < (int)(block_end - block_start)) {
-                piles_seg.indels[j + pos_rel]++;
-                if (params.call_variants) {
-                  vc->increment_mismatch(j + pos_rel - 1, string(op.Length, '-'), al.IsReverseStrand);
+	      if (al.Qualities.size() > (unsigned)k) {
+                if (al.MapQuality != 0 && j + pos_rel - 1 >= 0 && j + pos_rel < (int)(block_end - block_start)) {
+                  piles_seg.indels[j + pos_rel]++;
+                  if (params.call_variants) {
+                    vc->increment_mismatch(j + pos_rel - 1, string(op.Length, '-'), al.IsReverseStrand);
+                  }
                 }
-              }
+	      }
               for (int l = 0; l < op.Length; l++) {
                 piles_seg.depth[j + pos_rel]++;
                 j++;


### PR DESCRIPTION
Adam;
Thanks again for making the CAGe source available. I've been working on using it with some bwa mem data and ran into issues with support for hard clipped reads. This is my best stab at fixing the issue and allows CAGe to finish cleanly on my test input dataset, but I welcome suggestions: my C++ skills are pretty low so now sure if I'm tackling this the best way.

The data loader failed on bwa mem aligned output with hard clipping (H)
in the CIGAR strings. This adds support for it and also checks boundary
cases where we run over the ends of reads and get out_of_range errors
on the string.at checks.
